### PR TITLE
[UDL-1996] - Added log to cache to validate the issue is cached values

### DIFF
--- a/app/models/spree/calculator/avalara_transaction_calculator.rb
+++ b/app/models/spree/calculator/avalara_transaction_calculator.rb
@@ -39,7 +39,10 @@ module Spree
     end
 
     def get_avalara_response(order)
-      Rails.cache.fetch(cache_key(order), time_to_idle: 5.minutes) do
+      key = cache_key(order)
+      Rails.logger.info "[AVATAX] - Cache key for order #{order.number}: #{key}"
+      Rails.cache.fetch(key, time_to_idle: 5.minutes) do
+        Rails.logger.info "[AVATAX] - NO cache for key: #{key}"
         order.avalara_capture
       end
     end


### PR DESCRIPTION
### What problem is the code solving?
There are cases when avalara seems to be returning the V1 model, i suspect it may be cached values not being cleared.

### How does this change address the problem?
Add log to the cache to validate if the errors come from cached values
### Why is this the best solution?

### Share the knowledge

