### PR TITLE
[UDL-1667] - Incorrect address on mixed delivery orders

### DIFF
--- a/app/models/spree_avatax_certified/address.rb
+++ b/app/models/spree_avatax_certified/address.rb
@@ -140,7 +140,7 @@ module SpreeAvataxCertified
 
     def resolve_item_ship_to_address
       shipment = @order.shipments.select { |s| s.line_items.include?(@line) }
-      return shipment.address if shipment.present?
+      return shipment.first.address unless shipment.blank?
 
       order.pos? ? order.purchase_location.stock_location : order.ship_address
     end

--- a/app/models/spree_avatax_certified/line.rb
+++ b/app/models/spree_avatax_certified/line.rb
@@ -107,7 +107,7 @@ module SpreeAvataxCertified
     def return_item_line(line_item, quantity, amount)
       @logger.info("build return_line_item line: #{line_item.name}")
 
-      avatax_address = SpreeAvataxCertified::Address.new(@order,@order.line_items.first,@bill_address)
+      avatax_address = SpreeAvataxCertified::Address.new(@order,line_item,@bill_address)
 
       line = {
         :number => "#{line_item.id}-LI",


### PR DESCRIPTION
### What problem is the code solving?
Taxes are incorrectly informed for all Retail orders that are not 100% walkout. If the order has at least one item that was shipped to the customer, then the tax of that shipment will not be correctly calculated.

### How does this change address the problem?

Updates the mapping of the line's address to use the shipment corresponding to the item instead of the order one. This way if we have a split shipment or some bopis cases, we report the correct address

### Why is this the best solution?


### Share the knowledge

