### PR TITLE
[UDL-2121] - Avalara location reporting

### DIFF
--- a/app/models/spree/avalara_transaction.rb
+++ b/app/models/spree/avalara_transaction.rb
@@ -139,6 +139,7 @@ module Spree
         customerCode: customer_code,
         date: doc_date,
         companyCode: Spree::Config.avatax_company_code,
+        reportingLocationCode: resolve_location_code,
         entityUseCode: customer_usage_type,
         exemptionNo: order.user.try(:exemption_number),
         referenceCode: order.number,
@@ -164,6 +165,11 @@ module Spree
 
     def tax_calculation_enabled?
       Spree::Config.avatax_tax_calculation
+    end
+
+    def resolve_location_code
+      default_stock_location = Spree::StockLocation.find_by name: 'Mejuri'
+      order.purchase_location.stock_location.avalara_location_code || default_stock_location.avalara_location_code
     end
 
     def bill_to_address

--- a/app/models/spree/avalara_transaction.rb
+++ b/app/models/spree/avalara_transaction.rb
@@ -140,6 +140,7 @@ module Spree
         date: doc_date,
         companyCode: Spree::Config.avatax_company_code,
         reportingLocationCode: resolve_location_code,
+        currencyCode: order.currency,
         entityUseCode: customer_usage_type,
         exemptionNo: order.user.try(:exemption_number),
         referenceCode: order.number,


### PR DESCRIPTION
### What problem is the code solving?
Currently, Avalara transactions are missing store location sales detailed which is required for compliance. We need to add the location mapping to the avalara transactions.
### How does this change address the problem?
Adds a field to avalara stock locations to allow mapping the avalara code for each order
### Why is this the best solution?

### Share the knowledge
